### PR TITLE
anavi-thermometer.md: Fix formatting in flash instructions

### DIFF
--- a/anavi-thermometer/anavi-thermometer.md
+++ b/anavi-thermometer/anavi-thermometer.md
@@ -196,7 +196,7 @@ Follow the steps below to compile and flash custom firmware on ANAVI Thermometer
 
 1. To flash the firmware from Arduino IDE select Tools > Generic ESP8266 Module (Flash mode: DIO, Flash frequency: 40MHz, CPU frequency: 80MHz, Flash size: 512K, Debug port: Disabled, Debug level: None, Reset method: ck, Upload speed: 115200, Port: /dev/ttyUSB0). You might need to adjust the port if your USB to serial debug cable is connected on a different port.
 
-2.After that press load an Arduino sketch. [A simple blinking LED example is available at GitHub](https://github.com/AnaviTechnology/anavi-examples/blob/master/anavi-light-controller/anavi-blinking-led/anavi-blinking-led.ino)
+2. After that press load an Arduino sketch. [A simple blinking LED example is available at GitHub](https://github.com/AnaviTechnology/anavi-examples/blob/master/anavi-light-controller/anavi-blinking-led/anavi-blinking-led.ino)
 
 3. In Arudino IDE click Verify/Compile (Ctrl+R)
 


### PR DESCRIPTION
A missing space caused the list to be formatted badly.

Signed-off-by: Per Cederqvist <ceder@lysator.liu.se>